### PR TITLE
Don't use digicert action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,7 +110,7 @@ jobs:
             smctl sign verify --input $file 2>&1 > output.txt
             cat output.txt
             grep -v "Number of errors:" output.txt || exit 1
+            exit 1
             # signtool verify /pa /v $file
           done
 
-          exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,6 +106,8 @@ jobs:
           find .
           for file in $(find . -name '*.exe'); do
             echo "Verifying $file"
-            smctl sign verify --input $file 2>&1 | grep -v "exit status 1" || exit 1
+            smctl sign verify --input $file 2>&1 > output.txt
+            cat output.txt
+            grep -v "exit status 1" output.txt || exit 1
             # signtool verify /pa /v $file
           done

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,6 +108,6 @@ jobs:
             echo "Verifying $file"
             smctl sign verify --input $file 2>&1 > output.txt
             cat output.txt
-            grep -v "exit status 1" output.txt || exit 1
+            grep -v "Number of errors:" output.txt || exit 1
             # signtool verify /pa /v $file
           done

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,9 +13,10 @@ jobs:
   test-action:
     strategy:
       matrix:
-        # os: [ ubuntu-latest, ubuntu-20.04, windows-latest]
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, ubuntu-20.04, windows-latest]
+
     runs-on: ${{ matrix.os }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,6 +106,6 @@ jobs:
           find .
           for file in $(find . -name '*.exe'); do
             echo "Verifying $file"
-            # smctl sign verify --input $file | grep -v "errors" || exit 1
-            signtool verify /pa /v $file
+            smctl sign verify --input $file 2>&1 | grep -v "rrors" || exit 1
+            # signtool verify /pa /v $file
           done

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         # os: [ ubuntu-latest, ubuntu-20.04, windows-latest]
-        os: [ windows-latest]
+        os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,3 +112,5 @@ jobs:
             grep -v "Number of errors:" output.txt || exit 1
             # signtool verify /pa /v $file
           done
+
+          exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,8 @@ jobs:
   test-action:
     strategy:
       matrix:
-        os: [ ubuntu-latest, ubuntu-20.04, windows-latest]
+        # os: [ ubuntu-latest, ubuntu-20.04, windows-latest]
+        os: [ windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,13 +74,22 @@ jobs:
     runs-on: windows-latest
     needs: test-action
     steps:
-      # Download signtool.
-      - name: Configure Digicert Secure Software Manager
-        uses: digicert/ssm-code-signing@v0.0.2
+      - name: Install smtools
+        shell: cmd
         env:
-          SM_HOST: ${{ env.DIGICERT_HOST }}
           SM_API_KEY: ${{ env.SECRET_API_KEY }}
-          SM_CLIENT_CERT_PASSWORD: ${{ env.SECRET_PASSWORD }}
+        run: |
+          curl -X GET  https://one.digicert.com/signingmanager/api-ui/v1/releases/smtools-windows-x64.msi/download -H "x-api-key:%SM_API_KEY%" -o smtools-windows-x64.msi
+          msiexec /i smtools-windows-x64.msi /quiet /qn
+
+      - name: Set variables
+        shell: bash
+        id: variables
+        run: |
+          echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+          echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH
+          echo "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools" >> $GITHUB_PATH
+          echo "C:\Program Files\DigiCert\DigiCert One Signing Manager Tools" >> $GITHUB_PATH
 
       - name: Download signed files
         uses: actions/download-artifact@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,6 +106,6 @@ jobs:
           find .
           for file in $(find . -name '*.exe'); do
             echo "Verifying $file"
-            smctl sign verify --input $file || exit 1
+            smctl sign verify --input $file | grep -v "errors" || exit 1
             # signtool verify /pa /v $file
           done

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,6 +103,7 @@ jobs:
           SM_API_KEY: ${{ env.SECRET_API_KEY }}
           SM_CLIENT_CERT_PASSWORD: ${{ env.SECRET_PASSWORD }}
         run: |
+          set -e
           find .
           for file in $(find . -name '*.exe'); do
             echo "Verifying $file"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,6 +106,6 @@ jobs:
           find .
           for file in $(find . -name '*.exe'); do
             echo "Verifying $file"
-            smctl sign verify --input $file
+            smctl sign verify --input $file || exit 1
             # signtool verify /pa /v $file
           done

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,7 +109,7 @@ jobs:
             echo "Verifying $file"
             smctl sign verify --input $file 2>&1 > output.txt
             cat output.txt
-            grep "Number of errors:" output.txt && exit 1
+            grep "Number of errors:" output.txt && exit 1 || echo "$file verified"
             # signtool verify /pa /v $file
           done
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,8 +109,7 @@ jobs:
             echo "Verifying $file"
             smctl sign verify --input $file 2>&1 > output.txt
             cat output.txt
-            grep -v "Number of errors:" output.txt || exit 1
-            exit 1
+            grep "Number of errors:" output.txt && exit 1
             # signtool verify /pa /v $file
           done
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,6 +106,6 @@ jobs:
           find .
           for file in $(find . -name '*.exe'); do
             echo "Verifying $file"
-            smctl sign verify --input $file | grep -v "errors" || exit 1
-            # signtool verify /pa /v $file
+            # smctl sign verify --input $file | grep -v "errors" || exit 1
+            signtool verify /pa /v $file
           done

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,6 +106,6 @@ jobs:
           find .
           for file in $(find . -name '*.exe'); do
             echo "Verifying $file"
-            smctl sign verify --input $file 2>&1 | grep -v "rrors" || exit 1
+            smctl sign verify --input $file 2>&1 | grep -v "exit status 1" || exit 1
             # signtool verify /pa /v $file
           done

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 * @cognitedata/sec-eng
+* Toitware ApS

--- a/README.md
+++ b/README.md
@@ -30,8 +30,11 @@ on:
 
 jobs:
   run-action:
-    runs-on: windows-2022
+    runs-on: windows-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Run the action for a single file
         uses: toitlang/action-code-sign@v1
         with:
@@ -56,10 +59,10 @@ on:
 
 jobs:
   run-action-linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run the action for multiple files in directory
         uses: toitlang/action-code-sign@v1

--- a/action.yaml
+++ b/action.yaml
@@ -125,7 +125,7 @@ runs:
         # Create pkcs11properties.cfg
         echo -e "name=signingmanager\r\nlibrary=$PWD/smtools-linux-x64/smpkcs11.so\r\nslotListIndex=0" >> pkcs11properties.cfg
         cat pkcs11properties.cfg
-        # echo "PKCS11_CONFIG=$PWD/pkcs11properties.cfg" >> "$GITHUB_ENV"
+        echo "PKCS11_CONFIG=$PWD/pkcs11properties.cfg" >> "$GITHUB_ENV"
 
     - name: Create pkcs11properties.cfg
       if: runner.os == 'Linux' && (!contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE'))

--- a/action.yaml
+++ b/action.yaml
@@ -40,6 +40,11 @@ runs:
       shell: bash
       run: |
         echo "${{ inputs.certificate }}" | base64 --decode | sudo install -D /dev/stdin /d/code_signing_github_actions.p12
+        if [ "${{ runner.os }}" == "Windows" ]; then
+          echo "SM_CLIENT_CERT_FILE=D:\\code_signing_github_actions.p12" >> "$GITHUB_ENV"
+        elif [ "${{ runner.os }}" == "Linux" ]; then
+          echo "SM_CLIENT_CERT_FILE=/d/code_signing_github_actions.p12" >> "$GITHUB_ENV"
+        fi
 
 
     - name: Check that all required inputs are given
@@ -130,6 +135,7 @@ runs:
         curl -X GET  https://one.digicert.com/signingmanager/api-ui/v1/releases/smtools-linux-x64.tar.gz/download -H "x-api-key:$SM_API_KEY" -o linux-x64.tar.gz
         tar x -zf linux-x64.tar.gz
         echo "$PWD/smtools-linux-x64" >> $GITHUB_PATH
+        echo "PKCS11_CONFIG=$PWD/pkcs11properties.cfg" >> "$GITHUB_ENV"
 
     - name: Install Jsign for Linux signing
       if: runner.os == 'Linux' && (!contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE'))

--- a/action.yaml
+++ b/action.yaml
@@ -56,18 +56,6 @@ runs:
         [[ -s /d/code_signing_github_actions.p12 ]] || { echo "input 'certificate' is empty"; exit 1; }
         [[ -e "${{ inputs.path }}" ]] || { echo "input 'path' contains a non-existing file or folder: $p"; exit 1; }
 
-    - name: Set required variables
-      if: (!contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE'))
-      shell: bash
-      run: |
-        if [ "${{ runner.os }}" == "Windows" ]; then
-          echo "SM_CLIENT_CERT_FILE=D:\\code_signing_github_actions.p12" >> "$GITHUB_ENV"
-        elif [ "${{ runner.os }}" == "Linux" ]; then
-          echo "SM_CLIENT_CERT_FILE=/d/code_signing_github_actions.p12" >> "$GITHUB_ENV"
-          echo "PKCS11_CONFIG=/tmp/DigiCert One Signing Manager Tools/smtools-linux-x64/pkcs11properties.cfg" >> "$GITHUB_ENV"
-          # echo "/tmp/DigiCert One Signing Manager Tools/smtools-linux-x64" >> $GITHUB_PATH
-        fi
-
     - name: Inputs
       shell: bash
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -86,6 +86,19 @@ runs:
         curl -X GET  https://one.digicert.com/signingmanager/api-ui/v1/releases/smtools-windows-x64.msi/download -H "x-api-key:%SM_API_KEY%" -o smtools-windows-x64.msi
         msiexec /i smtools-windows-x64.msi /quiet /qn
 
+    - name: Set variables
+      shell: bash
+      id: variables
+      run: |
+        echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        echo "SM_HOST=${{ secrets.SM_HOST }}" >> $GITHUB_ENV
+        echo "SM_API_KEY=${{ secrets.SM_API_KEY }}" >> $GITHUB_ENV
+        echo "SM_CLIENT_CERT_FILE=D:\\Certificate_pkcs12.p12" >> $GITHUB_ENV
+        echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_CLIENT_CERT_PASSWORD }}" >> $GITHUB_ENV
+        echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH
+        echo "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools" >> $GITHUB_PATH
+        echo "C:\Program Files\DigiCert\DigiCert One Signing Manager Tools" >> $GITHUB_PATH
+
     - name: Configure Digicert
       if: ${{ runner.os == 'Windows' }}
       shell: cmd

--- a/action.yaml
+++ b/action.yaml
@@ -74,14 +74,35 @@ runs:
         echo "certificate-fingerprint: ${{ inputs.certificate-fingerprint }}"
         echo "path: ${{ inputs.path }}"
 
-    - name: Configure Digicert Secure Software Manager
-      if: ${{ !contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE') }}
-      uses: digicert/ssm-code-signing@v0.0.2
+    - name: Install smtools
+      if: ${{ runner.os == 'Windows' }}
+      shell: cmd
       env:
         SM_HOST: ${{ inputs.certificate-host }}
         SM_API_KEY: ${{ inputs.api-key }}
         SM_CLIENT_CERT_PASSWORD: ${{ inputs.certificate-password }}
         SM_CLIENT_CERT_FILE: ${{ env.SM_CLIENT_CERT_FILE }}
+      run: |
+        curl -X GET  https://one.digicert.com/signingmanager/api-ui/v1/releases/smtools-windows-x64.msi/download -H "x-api-key:%SM_API_KEY%" -o smtools-windows-x64.msi
+        msiexec /i smtools-windows-x64.msi /quiet /qn
+
+    - name: Configure Digicert
+      if: ${{ runner.os == 'Windows' }}
+      shell: cmd
+      run: |
+        smksp_registrar.exe list
+        smctl.exe keypair ls
+        C:\Windows\System32\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user
+        smksp_cert_sync.exe
+
+    # - name: Configure Digicert Secure Software Manager
+    #   if: ${{ !contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE') }}
+    #   uses: digicert/ssm-code-signing@v0.0.2
+    #   env:
+    #     SM_HOST: ${{ inputs.certificate-host }}
+    #     SM_API_KEY: ${{ inputs.api-key }}
+    #     SM_CLIENT_CERT_PASSWORD: ${{ inputs.certificate-password }}
+    #     SM_CLIENT_CERT_FILE: ${{ env.SM_CLIENT_CERT_FILE }}
 
     - name: Sign with smctl on Windows
       if: runner.os == 'Windows'

--- a/action.yaml
+++ b/action.yaml
@@ -46,7 +46,6 @@ runs:
           echo "SM_CLIENT_CERT_FILE=/d/code_signing_github_actions.p12" >> "$GITHUB_ENV"
         fi
 
-
     - name: Check that all required inputs are given
       shell: bash
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -77,6 +77,11 @@ runs:
       run: |
         curl -X GET  https://one.digicert.com/signingmanager/api-ui/v1/releases/smtools-windows-x64.msi/download -H "x-api-key:%SM_API_KEY%" -o smtools-windows-x64.msi
         msiexec /i smtools-windows-x64.msi /quiet /qn
+
+    - name: Set variables for Windows
+      if: runner.os == 'Windows' && (!contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE'))
+      shell: bash
+      run: |
         echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH
         echo "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools" >> $GITHUB_PATH
         echo "C:\Program Files\DigiCert\DigiCert One Signing Manager Tools" >> $GITHUB_PATH
@@ -140,7 +145,7 @@ runs:
         sudo dpkg --install jsign_3.1_all.deb
 
     - name: Sign with smctl on Linux
-      if: runner.os != 'Windows'
+      if: runner.os == 'Linux'
       shell: bash
       env:
         SM_HOST: ${{ inputs.certificate-host }}

--- a/action.yaml
+++ b/action.yaml
@@ -30,13 +30,13 @@ runs:
   using: "composite"
   steps:
     - name: Setup Certificate on Windows
-      if: ${{ runner.os == 'Windows' && (!contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE')) }}
+      if: runner.os == 'Windows' && (!contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE'))
       shell: bash
       run: |
         echo "${{ inputs.certificate }}" | base64 --decode > /d/code_signing_github_actions.p12
 
     - name: Setup Certificate on Linux
-      if: ${{ runner.os == 'Linux' && (!contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE')) }}
+      if: runner.os == 'Linux' && (!contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE'))
       shell: bash
       run: |
         echo "${{ inputs.certificate }}" | base64 --decode | sudo install -D /dev/stdin /d/code_signing_github_actions.p12
@@ -53,7 +53,7 @@ runs:
         [[ -e "${{ inputs.path }}" ]] || { echo "input 'path' contains a non-existing file or folder: $p"; exit 1; }
 
     - name: Set required variables
-      if: ${{ !contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE') }}
+      if: (!contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE'))
       shell: bash
       run: |
         if [ "${{ runner.os }}" == "Windows" ]; then
@@ -61,7 +61,7 @@ runs:
         elif [ "${{ runner.os }}" == "Linux" ]; then
           echo "SM_CLIENT_CERT_FILE=/d/code_signing_github_actions.p12" >> "$GITHUB_ENV"
           echo "PKCS11_CONFIG=/tmp/DigiCert One Signing Manager Tools/smtools-linux-x64/pkcs11properties.cfg" >> "$GITHUB_ENV"
-          echo "/tmp/DigiCert One Signing Manager Tools/smtools-linux-x64" >> $GITHUB_PATH
+          # echo "/tmp/DigiCert One Signing Manager Tools/smtools-linux-x64" >> $GITHUB_PATH
         fi
 
     - name: Inputs
@@ -75,7 +75,7 @@ runs:
         echo "path: ${{ inputs.path }}"
 
     - name: Install smtools for Windows
-      if: ${{ runner.os == 'Windows' }} && (!contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE'))
+      if: runner.os == 'Windows' && (!contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE'))
       shell: cmd
       env:
         SM_HOST: ${{ inputs.certificate-host }}
@@ -116,7 +116,7 @@ runs:
         }
 
     - name: Install smtools for Linux
-      if: ${{ runner.os == 'Linux' && (!contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE')) }}
+      if: runner.os == 'Linux' && (!contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE'))
       shell: bash
       env:
         SM_HOST: ${{ inputs.certificate-host }}
@@ -132,7 +132,7 @@ runs:
         echo "$PWD/smtools-linux-x64" >> $GITHUB_PATH
 
     - name: Install Jsign for Linux signing
-      if: ${{ runner.os == 'Linux' && (!contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE')) }}
+      if: runner.os == 'Linux' && (!contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE'))
       shell: bash
       run: |
         curl -fSslL https://github.com/ebourg/jsign/releases/download/3.1/jsign_3.1_all.deb -o jsign_3.1_all.deb

--- a/action.yaml
+++ b/action.yaml
@@ -136,7 +136,7 @@ runs:
         tar x -zf linux-x64.tar.gz
         echo "$PWD/smtools-linux-x64" >> $GITHUB_PATH
         # Create pkcs11properties.cfg
-        echo `name=signingmanager\r\nlibrary=$PWD/smpkcs11.so\r\nslotListIndex=0` >> pkcs11properties.cfg
+        echo "name=signingmanager\r\nlibrary=$PWD/smpkcs11.so\r\nslotListIndex=0" >> pkcs11properties.cfg
         cat pkcs11properties.cfg
         echo "PKCS11_CONFIG=$PWD/pkcs11properties.cfg" >> "$GITHUB_ENV"
 

--- a/action.yaml
+++ b/action.yaml
@@ -136,7 +136,7 @@ runs:
         tar x -zf linux-x64.tar.gz
         echo "$PWD/smtools-linux-x64" >> $GITHUB_PATH
         # Create pkcs11properties.cfg
-        echo -e "name=signingmanager\r\nlibrary=$PWD/smpkcs11.so\r\nslotListIndex=0" >> pkcs11properties.cfg
+        echo -e "name=signingmanager\r\nlibrary=$PWD/smtools-linux-x64/smpkcs11.so\r\nslotListIndex=0" >> pkcs11properties.cfg
         cat pkcs11properties.cfg
         echo "PKCS11_CONFIG=$PWD/pkcs11properties.cfg" >> "$GITHUB_ENV"
 

--- a/action.yaml
+++ b/action.yaml
@@ -34,17 +34,14 @@ runs:
       shell: bash
       run: |
         echo "${{ inputs.certificate }}" | base64 --decode > /d/code_signing_github_actions.p12
+        echo "SM_CLIENT_CERT_FILE=D:\\code_signing_github_actions.p12" >> "$GITHUB_ENV"
 
     - name: Setup Certificate on Linux
       if: runner.os == 'Linux' && (!contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE'))
       shell: bash
       run: |
         echo "${{ inputs.certificate }}" | base64 --decode | sudo install -D /dev/stdin /d/code_signing_github_actions.p12
-        if [ "${{ runner.os }}" == "Windows" ]; then
-          echo "SM_CLIENT_CERT_FILE=D:\\code_signing_github_actions.p12" >> "$GITHUB_ENV"
-        elif [ "${{ runner.os }}" == "Linux" ]; then
-          echo "SM_CLIENT_CERT_FILE=/d/code_signing_github_actions.p12" >> "$GITHUB_ENV"
-        fi
+        echo "SM_CLIENT_CERT_FILE=/d/code_signing_github_actions.p12" >> "$GITHUB_ENV"
 
     - name: Check that all required inputs are given
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -135,7 +135,14 @@ runs:
         curl -X GET  https://one.digicert.com/signingmanager/api-ui/v1/releases/smtools-linux-x64.tar.gz/download -H "x-api-key:$SM_API_KEY" -o linux-x64.tar.gz
         tar x -zf linux-x64.tar.gz
         echo "$PWD/smtools-linux-x64" >> $GITHUB_PATH
+        # Create pkcs11properties.cfg
+        echo `name=signingmanager\r\nlibrary=$PWD/smpkcs11.so\r\nslotListIndex=0` >> pkcs11properties.cfg
         echo "PKCS11_CONFIG=$PWD/pkcs11properties.cfg" >> "$GITHUB_ENV"
+
+    - name: Create pkcs11properties.cfg
+      if: runner.os == 'Linux' && (!contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE'))
+      shell: bash
+      run: |
 
     - name: Install Jsign for Linux signing
       if: runner.os == 'Linux' && (!contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE'))

--- a/action.yaml
+++ b/action.yaml
@@ -125,7 +125,7 @@ runs:
         # Create pkcs11properties.cfg
         echo -e "name=signingmanager\r\nlibrary=$PWD/smtools-linux-x64/smpkcs11.so\r\nslotListIndex=0" >> pkcs11properties.cfg
         cat pkcs11properties.cfg
-        echo "PKCS11_CONFIG=$PWD/pkcs11properties.cfg" >> "$GITHUB_ENV"
+        # echo "PKCS11_CONFIG=$PWD/pkcs11properties.cfg" >> "$GITHUB_ENV"
 
     - name: Create pkcs11properties.cfg
       if: runner.os == 'Linux' && (!contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE'))

--- a/action.yaml
+++ b/action.yaml
@@ -98,6 +98,12 @@ runs:
     - name: Configure Digicert
       if: ${{ runner.os == 'Windows' }}
       shell: cmd
+      env:
+        GITHUB_WORKSPACE: ${{ github.workspace }}
+        SM_HOST: ${{ inputs.certificate-host }}
+        SM_API_KEY: ${{ inputs.api-key }}
+        SM_CLIENT_CERT_PASSWORD: ${{ inputs.certificate-password }}
+        SM_CLIENT_CERT_FILE: ${{ env.SM_CLIENT_CERT_FILE }}
       run: |
         smksp_registrar.exe list
         smctl.exe keypair ls

--- a/action.yaml
+++ b/action.yaml
@@ -91,10 +91,6 @@ runs:
       id: variables
       run: |
         echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-        echo "SM_HOST=${{ secrets.SM_HOST }}" >> $GITHUB_ENV
-        echo "SM_API_KEY=${{ secrets.SM_API_KEY }}" >> $GITHUB_ENV
-        echo "SM_CLIENT_CERT_FILE=D:\\Certificate_pkcs12.p12" >> $GITHUB_ENV
-        echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_CLIENT_CERT_PASSWORD }}" >> $GITHUB_ENV
         echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH
         echo "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools" >> $GITHUB_PATH
         echo "C:\Program Files\DigiCert\DigiCert One Signing Manager Tools" >> $GITHUB_PATH

--- a/action.yaml
+++ b/action.yaml
@@ -95,20 +95,20 @@ runs:
         echo "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools" >> $GITHUB_PATH
         echo "C:\Program Files\DigiCert\DigiCert One Signing Manager Tools" >> $GITHUB_PATH
 
-    - name: Configure Digicert
-      if: ${{ runner.os == 'Windows' }}
-      shell: cmd
-      env:
-        GITHUB_WORKSPACE: ${{ github.workspace }}
-        SM_HOST: ${{ inputs.certificate-host }}
-        SM_API_KEY: ${{ inputs.api-key }}
-        SM_CLIENT_CERT_PASSWORD: ${{ inputs.certificate-password }}
-        SM_CLIENT_CERT_FILE: ${{ env.SM_CLIENT_CERT_FILE }}
-      run: |
-        smksp_registrar.exe list
-        smctl.exe keypair ls
-        C:\Windows\System32\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user
-        smksp_cert_sync.exe
+    # - name: Configure Digicert
+    #   if: ${{ runner.os == 'Windows' }}
+    #   shell: cmd
+    #   env:
+    #     GITHUB_WORKSPACE: ${{ github.workspace }}
+    #     SM_HOST: ${{ inputs.certificate-host }}
+    #     SM_API_KEY: ${{ inputs.api-key }}
+    #     SM_CLIENT_CERT_PASSWORD: ${{ inputs.certificate-password }}
+    #     SM_CLIENT_CERT_FILE: ${{ env.SM_CLIENT_CERT_FILE }}
+    #   run: |
+    #     smksp_registrar.exe list
+    #     smctl.exe keypair ls
+    #     C:\Windows\System32\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user
+    #     smksp_cert_sync.exe
 
     # - name: Configure Digicert Secure Software Manager
     #   if: ${{ !contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE') }}

--- a/action.yaml
+++ b/action.yaml
@@ -136,7 +136,7 @@ runs:
         tar x -zf linux-x64.tar.gz
         echo "$PWD/smtools-linux-x64" >> $GITHUB_PATH
         # Create pkcs11properties.cfg
-        echo "name=signingmanager\r\nlibrary=$PWD/smpkcs11.so\r\nslotListIndex=0" >> pkcs11properties.cfg
+        echo -e "name=signingmanager\r\nlibrary=$PWD/smpkcs11.so\r\nslotListIndex=0" >> pkcs11properties.cfg
         cat pkcs11properties.cfg
         echo "PKCS11_CONFIG=$PWD/pkcs11properties.cfg" >> "$GITHUB_ENV"
 

--- a/action.yaml
+++ b/action.yaml
@@ -74,8 +74,8 @@ runs:
         echo "certificate-fingerprint: ${{ inputs.certificate-fingerprint }}"
         echo "path: ${{ inputs.path }}"
 
-    - name: Install smtools
-      if: ${{ runner.os == 'Windows' }}
+    - name: Install smtools for Windows
+      if: ${{ runner.os == 'Windows' }} && (!contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE'))
       shell: cmd
       env:
         SM_HOST: ${{ inputs.certificate-host }}
@@ -85,39 +85,9 @@ runs:
       run: |
         curl -X GET  https://one.digicert.com/signingmanager/api-ui/v1/releases/smtools-windows-x64.msi/download -H "x-api-key:%SM_API_KEY%" -o smtools-windows-x64.msi
         msiexec /i smtools-windows-x64.msi /quiet /qn
-
-    - name: Set variables
-      shell: bash
-      id: variables
-      run: |
-        echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
         echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH
         echo "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools" >> $GITHUB_PATH
         echo "C:\Program Files\DigiCert\DigiCert One Signing Manager Tools" >> $GITHUB_PATH
-
-    # - name: Configure Digicert
-    #   if: ${{ runner.os == 'Windows' }}
-    #   shell: cmd
-    #   env:
-    #     GITHUB_WORKSPACE: ${{ github.workspace }}
-    #     SM_HOST: ${{ inputs.certificate-host }}
-    #     SM_API_KEY: ${{ inputs.api-key }}
-    #     SM_CLIENT_CERT_PASSWORD: ${{ inputs.certificate-password }}
-    #     SM_CLIENT_CERT_FILE: ${{ env.SM_CLIENT_CERT_FILE }}
-    #   run: |
-    #     smksp_registrar.exe list
-    #     smctl.exe keypair ls
-    #     C:\Windows\System32\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user
-    #     smksp_cert_sync.exe
-
-    # - name: Configure Digicert Secure Software Manager
-    #   if: ${{ !contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE') }}
-    #   uses: digicert/ssm-code-signing@v0.0.2
-    #   env:
-    #     SM_HOST: ${{ inputs.certificate-host }}
-    #     SM_API_KEY: ${{ inputs.api-key }}
-    #     SM_CLIENT_CERT_PASSWORD: ${{ inputs.certificate-password }}
-    #     SM_CLIENT_CERT_FILE: ${{ env.SM_CLIENT_CERT_FILE }}
 
     - name: Sign with smctl on Windows
       if: runner.os == 'Windows'
@@ -145,6 +115,22 @@ runs:
           smctl sign verify --input $f.FullName
         }
 
+    - name: Install smtools for Linux
+      if: ${{ runner.os == 'Linux' && (!contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE')) }}
+      shell: bash
+      env:
+        SM_HOST: ${{ inputs.certificate-host }}
+        SM_API_KEY: ${{ inputs.api-key }}
+        SM_CLIENT_CERT_PASSWORD: ${{ inputs.certificate-password }}
+        SM_CLIENT_CERT_FILE: ${{ env.SM_CLIENT_CERT_FILE }}
+      run: |
+        # Make a temporary directory to store the smtools
+        INSTALL_DIR=$(mktemp -d -t smtools-XXXXX)
+        cd $INSTALL_DIR
+        curl -X GET  https://one.digicert.com/signingmanager/api-ui/v1/releases/smtools-linux-x64.tar.gz/download -H "x-api-key:$SM_API_KEY" -o linux-x64.tar.gz
+        tar x -zf linux-x64.tar.gz
+        echo "$PWD/smtools-linux-x64" >> $GITHUB_PATH
+
     - name: Install Jsign for Linux signing
       if: ${{ runner.os == 'Linux' && (!contains(env.DIGICERT_DEPS_INSTALLED, 'TRUE')) }}
       shell: bash
@@ -153,7 +139,7 @@ runs:
         sudo dpkg --install jsign_3.1_all.deb
 
     - name: Sign with smctl on Linux
-      if: runner.os == 'Linux'
+      if: runner.os != 'Windows'
       shell: bash
       env:
         SM_HOST: ${{ inputs.certificate-host }}

--- a/action.yaml
+++ b/action.yaml
@@ -137,6 +137,7 @@ runs:
         echo "$PWD/smtools-linux-x64" >> $GITHUB_PATH
         # Create pkcs11properties.cfg
         echo `name=signingmanager\r\nlibrary=$PWD/smpkcs11.so\r\nslotListIndex=0` >> pkcs11properties.cfg
+        cat pkcs11properties.cfg
         echo "PKCS11_CONFIG=$PWD/pkcs11properties.cfg" >> "$GITHUB_ENV"
 
     - name: Create pkcs11properties.cfg


### PR DESCRIPTION
The digicert/ssm-code-signing action stopped working on 2024-02-08.
Don't use it anymore.
    
See https://github.com/digicert/ssm-code-signing/issues/19
